### PR TITLE
feat: enable navigate action, w/ react-router example

### DIFF
--- a/examples/react-router/app.jsx
+++ b/examples/react-router/app.jsx
@@ -1,0 +1,166 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { BrowserRouter } from 'react-router-dom';
+import { createWizard } from '../../src/index';
+import { Step, WizardProvider, useWizardContext } from './wizard-context';
+
+const First = () => {
+  const wizard = useWizardContext();
+
+  const onSubmit = event => {
+    event.preventDefault();
+    const data = new FormData(event.target);
+    const values = {};
+    data.forEach((value, field) => {
+      values[field] = value;
+    });
+    wizard.goToNextStep({ values });
+  };
+
+  return (
+    <>
+      <p className="font-semibold mb-8 underline uppercase">
+        {wizard.currentStep} step
+      </p>
+      <form onSubmit={onSubmit} className="mb-4">
+        <div className="mb-6">
+          <label
+            htmlFor="firstName"
+            id="firstName-label"
+            className="block mb-2"
+          >
+            First Name:
+          </label>
+          <input
+            className="border-2 border-solid border-gray-600 px-4 py-2"
+            type="text"
+            name="firstName"
+            id="firstName"
+            aria-label="firstName-label"
+            defaultValue={wizard.currentValues.firstName}
+          />
+        </div>
+        <div className="flex w-32 justify-between">
+          <button
+            type="button"
+            onClick={() => wizard.goToPreviousStep()}
+            className="p-3 mr-4"
+          >
+            Previous
+          </button>
+          <button type="submit" className="py-3 px-8 border-2 border-gray-900">
+            Next
+          </button>
+        </div>
+      </form>
+    </>
+  );
+};
+
+const Second = () => {
+  const wizard = useWizardContext();
+
+  const onSubmit = event => {
+    event.preventDefault();
+    const data = new FormData(event.target);
+    const values = {};
+    data.forEach((value, field) => {
+      values[field] = value;
+    });
+    wizard.goToNextStep({ values });
+  };
+
+  return (
+    <>
+      <p className="font-semibold mb-8 underline uppercase">
+        {wizard.currentStep} step
+      </p>
+      <form onSubmit={onSubmit} className="mb-4">
+        <div className="mb-6">
+          <label htmlFor="lastName" id="lastName-label" className="block mb-2">
+            Last Name:
+          </label>
+          <input
+            className="border-2 border-solid border-gray-600 px-4 py-2"
+            type="text"
+            name="lastName"
+            id="lastName"
+            aria-label="lastName-label"
+            defaultValue={wizard.currentValues.lastName}
+          />
+        </div>
+        <div className="flex w-32 justify-between">
+          <button
+            type="button"
+            onClick={() => wizard.goToPreviousStep()}
+            className="p-3 mr-4"
+          >
+            Previous
+          </button>
+          <button type="submit" className="py-3 px-8 border-2 border-gray-900">
+            Next
+          </button>
+        </div>
+      </form>
+    </>
+  );
+};
+
+const Third = () => {
+  const wizard = useWizardContext();
+
+  const onSubmit = event => {
+    event.preventDefault();
+    const data = new FormData(event.target);
+    const values = {};
+    data.forEach((value, field) => {
+      values[field] = value;
+    });
+    wizard.goToNextStep({ values });
+  };
+
+  return (
+    <>
+      <p className="font-semibold mb-8 underline uppercase">
+        {wizard.currentStep} step
+      </p>
+      <form onSubmit={onSubmit} className="mb-4">
+        <div className="mb-6">
+          <p className="text-green-600">
+            Welcome {wizard.currentValues.firstName}{' '}
+            {wizard.currentValues.lastName}!
+          </p>
+        </div>
+        <div className="flex w-32 justify-between">
+          <button
+            type="button"
+            onClick={() => wizard.goToPreviousStep()}
+            className="p-3 mr-4"
+          >
+            Previous
+          </button>
+          <button type="submit" className="py-3 px-8 border-2 border-gray-900">
+            Next
+          </button>
+        </div>
+      </form>
+    </>
+  );
+};
+
+const App = () => {
+  return (
+    <div className="px-5">
+      <h1 className="text-2xl font-bold">Robo Wizard</h1>
+      <BrowserRouter>
+        <WizardProvider initialValues={{ firstName: '', lastName: '' }}>
+          <Step name="first" component={First} />
+          <Step name="second" component={Second} />
+          <Step name="third" component={Third} />
+        </WizardProvider>
+      </BrowserRouter>
+    </div>
+  );
+};
+
+ReactDOM.render(<App />, document.getElementById('app'));

--- a/examples/react-router/index.html
+++ b/examples/react-router/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Robo-Wizard Example App</title>
+    <link
+      href="https://unpkg.com/tailwindcss@^1.0/dist/tailwind.min.css"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="./app.jsx"></script>
+  </body>
+</html>

--- a/examples/react-router/package.json
+++ b/examples/react-router/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "react-router",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "parcel index.html --host 0.0.0.0"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1",
+    "react-router-dom": "^5.2.0"
+  },
+  "devDependencies": {
+    "parcel-bundler": "^1.12.3"
+  }
+}

--- a/examples/react-router/wizard-context.jsx
+++ b/examples/react-router/wizard-context.jsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { Route, useHistory, Switch, Redirect } from 'react-router-dom';
+import { createWizard } from '../../src/index';
+
+const WizardContext = React.createContext(null);
+
+export function Step({ name, ...routeProps }) {
+  return <Route path={`/${name}`} {...routeProps} />;
+}
+
+export function WizardProvider({ children, initialValues }) {
+  const steps = React.Children.map(children, child => {
+    if (child.type === Step) return child.props;
+    return null;
+  }).filter(Boolean);
+  const wizard = useWizard(steps, initialValues);
+
+  return (
+    <WizardContext.Provider value={wizard}>
+      {children}
+      <Switch>
+        <Redirect from="/" to={`/${steps[0].name}`} exact />
+      </Switch>
+    </WizardContext.Provider>
+  );
+}
+
+export function useWizardContext() {
+  const wizard = React.useContext(WizardContext);
+  return wizard;
+}
+
+function useWizard(steps, initialValues) {
+  const history = useHistory();
+  const [_, refreshState] = React.useState(false);
+  const [currentWizard, setWizard] = React.useState(() => {
+    const wizard = createWizard(steps, initialValues, {
+      navigate: () => {
+        history.push(`/${wizard.currentStep}`);
+      },
+    });
+    wizard.start(() => refreshState(s => !s));
+    return wizard;
+  });
+  return currentWizard;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -292,7 +292,10 @@ function getNextTargets<Values extends object>(
  */
 export function createWizard<Values extends object = BaseValues>(
   steps: FlowStep<Values>[],
-  initialValues: Values = {} as Values
+  initialValues: Values = {} as Values,
+  actions: {
+    navigate: StateMachine.ActionFunction<Values, WizardEvent<Values>>;
+  }
 ) {
   const normalizedSteps: StepConfig<Values>[] = steps.map(step =>
     typeof step === 'string' ? { name: step } : step
@@ -305,6 +308,7 @@ export function createWizard<Values extends object = BaseValues>(
       StateMachine.Config<Values, WizardEvent<Values>>['states']
     >((result, step, index) => {
       result[step.name] = {
+        entry: ['navigate'],
         on: {
           previous: {
             target: getPreviousTarget(step, index, normalizedSteps),
@@ -330,6 +334,7 @@ export function createWizard<Values extends object = BaseValues>(
   );
   const machine = createMachine(config, {
     actions: {
+      ...actions,
       assignNewValues,
     },
   });


### PR DESCRIPTION
Spiking on an implementation of routed transitions through a generic `navigate` action as demonstrated with the included `react-router` example. 

TODO:
- [ ] enable syncing with the current location after using browser actions (back/forward buttons)
- [ ] fake parameterized actions by passing the current step to `navigate`
- [ ] add HTML example
- [ ] update tests
- [ ] React `navigate` should happen in `useEffect` (?)